### PR TITLE
fix: use defineCloudflareConfig helper in open-next config

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,7 +1,3 @@
-import type { OpenNextConfig } from "@opennextjs/cloudflare";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
-const config: OpenNextConfig = {
-  // Default config for Cloudflare Pages
-};
-
-export default config;
+export default defineCloudflareConfig({});


### PR DESCRIPTION
## Summary
- Fix TypeScript error in open-next.config.ts
- Use `defineCloudflareConfig` helper instead of raw type assertion

## Changes
The previous configuration caused build errors:
```
Type error: Property 'default' is missing in type '{}' but required in type 'OpenNextConfig'.
```

Updated to match the pattern used in the web project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)