### PR TITLE
feat: add pagination to recoveries and catalog pages

### DIFF
--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  totalCount: number;
+  itemsShown: number;
+  itemName?: string;
+  basePath: string;
+}
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  totalCount,
+  itemsShown,
+  itemName = 'items',
+  basePath,
+}: PaginationProps) {
+  const router = useRouter();
+
+  const handlePageChange = (newPage: number) => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('page', newPage.toString());
+    router.push(`${basePath}?${params.toString()}`);
+  };
+
+  if (totalPages <= 1) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Showing {itemsShown} {itemName}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between">
+      <p className="text-sm text-muted-foreground">
+        Showing {itemsShown} of {totalCount} {itemName}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => handlePageChange(currentPage - 1)}
+          disabled={currentPage <= 1}
+          aria-label="Go to previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Previous
+        </Button>
+        <span className="text-sm" aria-live="polite">
+          Page {currentPage} of {totalPages}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => handlePageChange(currentPage + 1)}
+          disabled={currentPage >= totalPages}
+          aria-label="Go to next page"
+        >
+          Next
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Create reusable Pagination component with keyboard navigation and ARIA labels
- Add server-side pagination to Recoveries page (20 items per page)
- Add server-side pagination to Catalog page (50 items per page)
- Use Supabase count queries for accurate total counts

Note: Orders and Users pages already had pagination implemented.

## Test plan

- [ ] Navigate to Recoveries page and verify pagination controls appear
- [ ] Navigate to Catalog page and verify pagination controls appear
- [ ] Test Previous/Next buttons for proper page navigation
- [ ] Verify filter parameters are preserved when changing pages
- [ ] Check that page count updates when filters are applied

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)