### PR TITLE
fix: add server-side authorization checks on protected pages

### DIFF
--- a/src/app/(dashboard)/ai/page.tsx
+++ b/src/app/(dashboard)/ai/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -37,6 +38,9 @@ function formatConfidence(confidence: number | null) {
 }
 
 export default async function AIInsightsPage() {
+  // Server-side authorization check - admin only
+  await requireAdmin();
+
   const supabase = await createClient();
 
   // Fetch AI identification metrics

--- a/src/app/(dashboard)/catalog/page.tsx
+++ b/src/app/(dashboard)/catalog/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -50,6 +51,9 @@ interface PageProps {
 }
 
 export default async function DiscCatalogPage({ searchParams }: PageProps) {
+  // Server-side authorization check - admin only
+  await requireAdmin();
+
   const params = await searchParams;
   const supabase = await createClient();
 

--- a/src/app/(dashboard)/orders/[id]/page.tsx
+++ b/src/app/(dashboard)/orders/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdminOrPrinter } from '@/lib/auth';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -50,6 +51,9 @@ function formatCurrency(cents: number) {
 }
 
 export default async function OrderDetailPage({ params }: OrderPageProps) {
+  // Server-side authorization check - admin or printer
+  await requireAdminOrPrinter();
+
   const { id } = await params;
   const supabase = await createClient();
 

--- a/src/app/(dashboard)/orders/page.tsx
+++ b/src/app/(dashboard)/orders/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdminOrPrinter } from '@/lib/auth';
 import { OrdersTable } from './orders-table';
 import { OrderFilters } from './order-filters';
 
@@ -15,6 +16,9 @@ export default async function OrdersPage({
 }: {
   searchParams: Promise<SearchParams>;
 }) {
+  // Server-side authorization check - admin or printer
+  await requireAdminOrPrinter();
+
   const params = await searchParams;
   const supabase = await createClient();
 

--- a/src/app/(dashboard)/payments/page.tsx
+++ b/src/app/(dashboard)/payments/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -48,6 +49,9 @@ const statusColors: Record<string, string> = {
 };
 
 export default async function PaymentsPage() {
+  // Server-side authorization check - admin only
+  await requireAdmin();
+
   const supabase = await createClient();
 
   // Get all orders for stats

--- a/src/app/(dashboard)/qr-codes/page.tsx
+++ b/src/app/(dashboard)/qr-codes/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -36,6 +37,9 @@ const statusIcons: Record<string, React.ReactNode> = {
 };
 
 export default async function QRCodesPage() {
+  // Server-side authorization check - admin only
+  await requireAdmin();
+
   const supabase = await createClient();
 
   // Get all QR codes for stats

--- a/src/app/(dashboard)/recoveries/page.tsx
+++ b/src/app/(dashboard)/recoveries/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -56,6 +57,9 @@ interface PageProps {
 }
 
 export default async function RecoveriesPage({ searchParams }: PageProps) {
+  // Server-side authorization check - admin only
+  await requireAdmin();
+
   const params = await searchParams;
   const supabase = await createClient();
 

--- a/src/app/(dashboard)/system/page.tsx
+++ b/src/app/(dashboard)/system/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -23,6 +24,9 @@ import {
 export const dynamic = 'force-dynamic';
 
 export default async function SystemPage() {
+  // Server-side authorization check - admin only
+  await requireAdmin();
+
   const supabase = await createClient();
 
   // Notification health - users with push tokens

--- a/src/app/(dashboard)/users/[id]/page.tsx
+++ b/src/app/(dashboard)/users/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -95,6 +96,9 @@ export default async function UserDetailPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
+  // Server-side authorization check - admin only
+  await requireAdmin();
+
   const { id } = await params;
   const supabase = await createClient();
 

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth';
 import { UsersTable } from './users-table';
 import { UserFilters } from './user-filters';
 
@@ -15,6 +16,9 @@ export default async function UsersPage({
 }: {
   searchParams: Promise<SearchParams>;
 }) {
+  // Server-side authorization check - admin only
+  await requireAdmin();
+
   const params = await searchParams;
   const supabase = await createClient();
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock redirect - must be before importing auth
+const mockRedirect = vi.fn();
+vi.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    mockRedirect(url);
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
+// Mock Supabase server client
+const mockGetUser = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  })),
+}));
+
+import {
+  getAuthenticatedUser,
+  requireAdmin,
+  requireAdminOrPrinter,
+} from './auth';
+
+describe('auth utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAuthenticatedUser', () => {
+    it('returns null when no user is authenticated', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      const result = await getAuthenticatedUser();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when user has no role', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'user-123',
+            email: 'test@example.com',
+            app_metadata: {},
+          },
+        },
+        error: null,
+      });
+
+      const result = await getAuthenticatedUser();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when user has invalid role', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'user-123',
+            email: 'test@example.com',
+            app_metadata: { role: 'invalid' },
+          },
+        },
+        error: null,
+      });
+
+      const result = await getAuthenticatedUser();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns auth result for admin user', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'admin-123',
+            email: 'admin@example.com',
+            app_metadata: { role: 'admin' },
+          },
+        },
+        error: null,
+      });
+
+      const result = await getAuthenticatedUser();
+
+      expect(result).toEqual({
+        user: {
+          id: 'admin-123',
+          email: 'admin@example.com',
+        },
+        role: 'admin',
+      });
+    });
+
+    it('returns auth result for printer user', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'printer-123',
+            email: 'printer@example.com',
+            app_metadata: { role: 'printer' },
+          },
+        },
+        error: null,
+      });
+
+      const result = await getAuthenticatedUser();
+
+      expect(result).toEqual({
+        user: {
+          id: 'printer-123',
+          email: 'printer@example.com',
+        },
+        role: 'printer',
+      });
+    });
+  });
+
+  describe('requireAdmin', () => {
+    it('redirects to /unauthorized when no user is authenticated', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      await expect(requireAdmin()).rejects.toThrow('NEXT_REDIRECT:/unauthorized');
+      expect(mockRedirect).toHaveBeenCalledWith('/unauthorized');
+    });
+
+    it('redirects to /unauthorized when user has no valid role', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'user-123',
+            email: 'test@example.com',
+            app_metadata: {},
+          },
+        },
+        error: null,
+      });
+
+      await expect(requireAdmin()).rejects.toThrow('NEXT_REDIRECT:/unauthorized');
+      expect(mockRedirect).toHaveBeenCalledWith('/unauthorized');
+    });
+
+    it('redirects to /orders when user is a printer', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'printer-123',
+            email: 'printer@example.com',
+            app_metadata: { role: 'printer' },
+          },
+        },
+        error: null,
+      });
+
+      await expect(requireAdmin()).rejects.toThrow('NEXT_REDIRECT:/orders');
+      expect(mockRedirect).toHaveBeenCalledWith('/orders');
+    });
+
+    it('returns auth result for admin user', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'admin-123',
+            email: 'admin@example.com',
+            app_metadata: { role: 'admin' },
+          },
+        },
+        error: null,
+      });
+
+      const result = await requireAdmin();
+
+      expect(result).toEqual({
+        user: {
+          id: 'admin-123',
+          email: 'admin@example.com',
+        },
+        role: 'admin',
+      });
+    });
+  });
+
+  describe('requireAdminOrPrinter', () => {
+    it('redirects to /unauthorized when no user is authenticated', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      await expect(requireAdminOrPrinter()).rejects.toThrow(
+        'NEXT_REDIRECT:/unauthorized'
+      );
+      expect(mockRedirect).toHaveBeenCalledWith('/unauthorized');
+    });
+
+    it('redirects to /unauthorized when user has no valid role', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'user-123',
+            email: 'test@example.com',
+            app_metadata: { role: 'invalid' },
+          },
+        },
+        error: null,
+      });
+
+      await expect(requireAdminOrPrinter()).rejects.toThrow(
+        'NEXT_REDIRECT:/unauthorized'
+      );
+      expect(mockRedirect).toHaveBeenCalledWith('/unauthorized');
+    });
+
+    it('returns auth result for admin user', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'admin-123',
+            email: 'admin@example.com',
+            app_metadata: { role: 'admin' },
+          },
+        },
+        error: null,
+      });
+
+      const result = await requireAdminOrPrinter();
+
+      expect(result).toEqual({
+        user: {
+          id: 'admin-123',
+          email: 'admin@example.com',
+        },
+        role: 'admin',
+      });
+    });
+
+    it('returns auth result for printer user', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'printer-123',
+            email: 'printer@example.com',
+            app_metadata: { role: 'printer' },
+          },
+        },
+        error: null,
+      });
+
+      const result = await requireAdminOrPrinter();
+
+      expect(result).toEqual({
+        user: {
+          id: 'printer-123',
+          email: 'printer@example.com',
+        },
+        role: 'printer',
+      });
+    });
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,74 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+
+export type UserRole = 'admin' | 'printer';
+
+interface AuthResult {
+  user: {
+    id: string;
+    email: string | undefined;
+  };
+  role: UserRole;
+}
+
+/**
+ * Get the current user and their role from the server.
+ * Returns null if not authenticated.
+ */
+export async function getAuthenticatedUser(): Promise<AuthResult | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const role = user.app_metadata?.role as UserRole | undefined;
+
+  if (role !== 'admin' && role !== 'printer') {
+    return null;
+  }
+
+  return {
+    user: {
+      id: user.id,
+      email: user.email,
+    },
+    role,
+  };
+}
+
+/**
+ * Require admin role for a page. Redirects to /orders if user is a printer,
+ * or /unauthorized if user has no valid role.
+ */
+export async function requireAdmin(): Promise<AuthResult> {
+  const auth = await getAuthenticatedUser();
+
+  if (!auth) {
+    redirect('/unauthorized');
+  }
+
+  if (auth.role !== 'admin') {
+    // Printer users get redirected to orders
+    redirect('/orders');
+  }
+
+  return auth;
+}
+
+/**
+ * Require admin or printer role for a page.
+ * Redirects to /unauthorized if user has no valid role.
+ */
+export async function requireAdminOrPrinter(): Promise<AuthResult> {
+  const auth = await getAuthenticatedUser();
+
+  if (!auth) {
+    redirect('/unauthorized');
+  }
+
+  return auth;
+}


### PR DESCRIPTION
## Summary

- Created `src/lib/auth.ts` with `requireAdmin()` and `requireAdminOrPrinter()` utility functions for server-side authorization verification
- Added server-side role checks to all protected pages to prevent direct URL access bypass
- Admin-only pages (users, catalog, payments, system, qr-codes, ai, recoveries) now call `requireAdmin()` before rendering
- Orders pages call `requireAdminOrPrinter()` to allow both admin and printer roles
- Unauthorized admin access redirects to `/orders` (for printer role) or `/unauthorized` (for no role)
- Added comprehensive tests for auth utilities (13 test cases)

## Test plan

- [ ] Verify admin user can access all pages normally
- [ ] Verify printer user can only access /orders pages
- [ ] Verify printer user is redirected to /orders when trying to access admin-only pages
- [ ] Verify unauthenticated user is redirected to /unauthorized
- [ ] Run `npm test` to verify all auth tests pass

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)