### PR TITLE
feat: unify dark mode colors with Material Design standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,27 @@ export async function requireAdminOrPrinter() {
 | Add auth check | Use `requireAdmin()` or `requireAdminOrPrinter()` at page top |
 | Change colors | `src/app/globals.css` (CSS variables) |
 
+### Unified Color System (consistent across mobile, web, admin)
+
+**Dark Mode Surfaces (Material Design elevation):**
+
+| Purpose | Hex | oklch | CSS Variable |
+|---------|-----|-------|--------------|
+| Background | `#121212` | `oklch(0.178 0 0)` | `--background` |
+| Card/Surface | `#1e1e1e` | `oklch(0.205 0 0)` | `--card` |
+| Elevated | `#252525` | `oklch(0.227 0 0)` | `--secondary`, `--accent` |
+| Border | `#2e2e2e` | `oklch(0.252 0 0)` | `--border` |
+
+**Usage in Components:**
+
+```typescript
+// Use Tailwind classes that reference CSS variables
+<div className="bg-background">         {/* #121212 in dark */}
+<div className="bg-card">               {/* #1e1e1e in dark */}
+<div className="bg-secondary">          {/* #252525 in dark */}
+<div className="border-border">         {/* #2e2e2e in dark */}
+```
+
 ### Adding a New Dashboard Page
 
 1. Create `src/app/(dashboard)/feature/page.tsx`:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,36 +82,37 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  /* Unified dark mode colors: #121212 bg, #1e1e1e card, #252525 elevated, #2e2e2e border */
+  --background: oklch(0.178 0 0); /* #121212 */
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(0.205 0 0); /* #1e1e1e */
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
+  --popover: oklch(0.205 0 0); /* #1e1e1e */
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.922 0 0);
   --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
+  --secondary: oklch(0.227 0 0); /* #252525 - elevated */
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
+  --muted: oklch(0.227 0 0); /* #252525 - elevated */
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
+  --accent: oklch(0.227 0 0); /* #252525 - elevated */
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
+  --border: oklch(0.252 0 0); /* #2e2e2e */
+  --input: oklch(0.227 0 0); /* #252525 - elevated */
   --ring: oklch(0.556 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: oklch(0.205 0 0); /* #1e1e1e - card level */
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent: oklch(0.227 0 0); /* #252525 - elevated */
   --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-border: oklch(0.252 0 0); /* #2e2e2e */
   --sidebar-ring: oklch(0.556 0 0);
 }
 


### PR DESCRIPTION
## Summary

- Update dark mode background from `#000` to `#121212` (Material Design standard)
- Update card/surface colors from `#1a1a1a` to `#1e1e1e`
- Add `darkSurface` object to `Colors.ts` for consistent access
- Update all 38 screens/components with new color values
- Update CLAUDE.md with unified color system documentation

## Unified Color System

| Purpose | Hex | Description |
|---------|-----|-------------|
| Background | `#121212` | Main app background |
| Card/Surface | `#1e1e1e` | Cards, modals, surfaces |
| Elevated | `#252525` | Inputs, hover states |
| Border | `#2e2e2e` | Dividers, borders |

This change improves contrast with the violet brand colors and aligns with Material Design dark theme guidelines.

## Test plan

- [ ] Test app in dark mode on iOS
- [ ] Test app in dark mode on Android
- [ ] Verify violet buttons/accents are visible against new backgrounds
- [ ] Check all screens for proper contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)