### PR TITLE
fix: prevent redirect loop on unauthorized page

### DIFF
--- a/src/lib/supabase/middleware.test.ts
+++ b/src/lib/supabase/middleware.test.ts
@@ -228,6 +228,53 @@ describe('updateSession middleware', () => {
     });
   });
 
+  describe('unauthorized page', () => {
+    it('allows access to unauthorized page without authentication', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+
+      const request = createMockRequest('/unauthorized');
+      const response = await updateSession(request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it('allows access to unauthorized page for users without valid role', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'user-123',
+            email: 'regular@test.com',
+            app_metadata: {},
+          },
+        },
+      });
+
+      const request = createMockRequest('/unauthorized');
+      const response = await updateSession(request);
+
+      // Should NOT redirect, preventing redirect loop
+      expect(response.status).toBe(200);
+    });
+
+    it('allows access to unauthorized page for users with invalid role', async () => {
+      mockGetUser.mockResolvedValue({
+        data: {
+          user: {
+            id: 'user-123',
+            email: 'user@test.com',
+            app_metadata: { role: 'viewer' },
+          },
+        },
+      });
+
+      const request = createMockRequest('/unauthorized');
+      const response = await updateSession(request);
+
+      // Should NOT redirect, preventing redirect loop
+      expect(response.status).toBe(200);
+    });
+  });
+
   describe('unauthorized access', () => {
     it('redirects users without role to unauthorized', async () => {
       mockGetUser.mockResolvedValue({

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -44,6 +44,11 @@ export async function updateSession(request: NextRequest) {
     return supabaseResponse;
   }
 
+  // Allow access to unauthorized page (to prevent redirect loops)
+  if (pathname === '/unauthorized') {
+    return supabaseResponse;
+  }
+
   // Require authentication for all other routes
   if (!user) {
     return NextResponse.redirect(new URL('/login', request.url));


### PR DESCRIPTION
## Summary

- Allow access to `/unauthorized` page before checking authentication or role
- Prevents infinite redirect loops when users without admin/printer roles access the admin dashboard
- Added tests for unauthorized page access scenarios

## Test plan

- [x] Tests pass for unauthorized page access with no user
- [x] Tests pass for unauthorized page access with user lacking valid role
- [x] Tests pass for unauthorized page access with user having invalid role
- [ ] Deploy and verify user without admin role sees unauthorized page instead of redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)