### PR TITLE
fix: add merge_group trigger to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,7 @@
 ---
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary

- Adds `merge_group:` event trigger to CI workflows
- Fixes PRs getting stuck in the merge queue indefinitely

## Why

The merge queue rule is configured with required status checks, but none of the workflows were listening for the `merge_group` event. GitHub's merge queue runs CI against a temporary merge group branch — without this trigger the required checks never reported, and the queue would sit waiting until the 60-minute timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)