### PR TITLE
chore: block eslint v10 in renovate until eslint-config-next supports it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
       "matchPackageNames": ["eslint", "/^@eslint//", "/^eslint-plugin-/", "/^@typescript-eslint//"]
     },
     {
+      "description": "Block ESLint v10 - eslint-plugin-react (via eslint-config-next) does not support it yet",
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "<10"
+    },
+    {
       "description": "Group React packages",
       "groupName": "react packages",
       "matchPackageNames": ["/^react/", "/^@types/react/"]


### PR DESCRIPTION
## Summary

Adds an `allowedVersions: "<10"` rule for `eslint` in `renovate.json` to prevent Renovate from re-proposing the ESLint v10 upgrade.

## Why

`constraintsFiltering: strict` (added in #78) doesn't catch this specific conflict because `eslint-plugin-react` is a *transitive* dependency of `eslint-config-next`, not a direct project dependency. Renovate only checks peer deps of direct dependencies, so it keeps re-opening the v10 upgrade (first as #70, then again as #79 after we closed it).

The explicit cap stays in place until `eslint-config-next` ships a version whose dep tree supports ESLint v10 — at that point, remove the `allowedVersions` rule and let Renovate upgrade both together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)