### PR TITLE
chore: remove ESLint Renovate rules now at org level

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>discrapp/.github"],
-  "constraintsFiltering": "strict",
   "packageRules": [
-    {
-      "description": "Group ESLint ecosystem - must upgrade together to avoid peer dep conflicts",
-      "groupName": "eslint packages",
-      "matchPackageNames": ["eslint", "/^@eslint//", "/^eslint-plugin-/", "/^@typescript-eslint//"]
-    },
-    {
-      "description": "Block ESLint v10 - eslint-plugin-react (via eslint-config-next) does not support it yet",
-      "matchPackageNames": ["eslint"],
-      "allowedVersions": "<10"
-    },
     {
       "description": "Group React packages",
       "groupName": "react packages",


### PR DESCRIPTION
## Summary

Removes `constraintsFiltering`, ESLint ecosystem group, and `allowedVersions: "<10"` from this repo's `renovate.json` — they're now in the shared `discrapp/.github` preset and inherited automatically.

Depends on discrapp/.github#20 merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)